### PR TITLE
Fix shutdown hang in profiler builds by dropping tracy flush-on-exit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rustls-native-certs = "0.8"
 rustls-pemfile = "2"
 signal-hook = "0.4"
 socket2 = "0.6"
-tracy-client = { version = "0.18", default-features = false, features = ["enable", "only-localhost", "sampling", "flush-on-exit"], optional = true }
+tracy-client = { version = "0.18", default-features = false, features = ["enable", "only-localhost", "sampling"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 tokio = { version = "1", default-features = false, features = ["io-util"] }

--- a/README.md
+++ b/README.md
@@ -299,8 +299,11 @@ code is executing.
 
 Linux and macOS release wheels are built with profiler support enabled. Other
 builds still need `--features profiler` when built locally. The Tracy feature
-set is aimed at local profiling: `enable`, `only-localhost`, `sampling`, and
-`flush-on-exit`. The last one helps short-lived runs flush data before exit.
+set is aimed at local profiling: `enable`, `only-localhost`, and `sampling`.
+
+For very short-lived runs you can force the process to block on exit until a
+server has connected and drained all data by setting `TRACY_NO_EXIT=1` in the
+environment.
 
 If the extension was built without `--features profiler`, `profile()` and
 `start_profiler()` raise a runtime error.


### PR DESCRIPTION
The `flush-on-exit` tracy-client feature defines TRACY_NO_EXIT, which removes the connection-wait exit check from Tracy's worker loop. Since the client also runs from library load (no manual-lifetime), every profiler-enabled import starts a Tracy worker that, then at interpreter teardown, blocks forever in ListenSocket::Accept() waiting for a server that never connects.

For the cases where it's desired it can be re-enabled at runtime by setting `TRACY_NO_EXIT=1` as env-var.


Fixes #50 