### PR TITLE
Don't panic on non-finite values to sleep/call_at

### DIFF
--- a/src/python_api.rs
+++ b/src/python_api.rs
@@ -40,6 +40,11 @@ use crate::tls::{client_tls_settings, server_tls_settings};
 
 const WSAEISCONN: i32 = 10056;
 
+/// Upper bound (~1 century) for timer delays, so math.inf and other oversized
+/// values clamp to a far-future deadline instead of panicking the conversion
+/// to `Duration`/`Instant` (issue #48).
+const MAX_TIMER_DELAY_SECS: f64 = 100.0 * 365.0 * 24.0 * 60.0 * 60.0;
+
 struct PythonApiCaches {
     asyncio_task_cls: OnceLock<Py<PyAny>>,
     asyncio_future_cls: OnceLock<Py<PyAny>>,
@@ -1362,7 +1367,12 @@ impl PyLoop {
         args: &Bound<'_, PyTuple>,
         context: Option<Py<PyAny>>,
     ) -> PyResult<Py<PyTimerHandle>> {
-        let delay = delay.max(0.0);
+        // Clamp so math.inf / oversized delays never panic
+        // Duration::from_secs_f64 (issue #48); negatives fire ASAP.
+        if delay.is_nan() {
+            return Err(PyValueError::new_err("delay cannot be NaN"));
+        }
+        let delay = delay.clamp(0.0, MAX_TIMER_DELAY_SECS);
         let (ready, when) = self.core.schedule_timer(
             py,
             Duration::from_secs_f64(delay),
@@ -1383,8 +1393,8 @@ impl PyLoop {
         args: &Bound<'_, PyTuple>,
         context: Option<Py<PyAny>>,
     ) -> PyResult<Py<PyTimerHandle>> {
-        let delay = (when - self.time()).max(0.0);
-        self.call_later(py, delay, callback, args, context)
+        // call_later clamps negatives and rejects NaN; don't mask either here.
+        self.call_later(py, when - self.time(), callback, args, context)
     }
 
     fn time(&self) -> f64 {

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -268,6 +268,35 @@ class CompatibilityTests(unittest.TestCase):
         self.assertEqual(received, b"external-socket-data")
         self.assertLess(elapsed, 0.5)
 
+    def test_call_later_raises_for_nan(self) -> None:
+        # Regression for upstream issue #48: math.inf / oversized delays used to
+        # panic in Duration::from_secs_f64. They must now schedule without firing
+        # prematurely (inf, huge), fire ASAP (negative), and reject NaN.
+        async def main() -> None:
+            loop = asyncio.get_running_loop()
+
+            with self.assertRaises(ValueError):
+                loop.call_later(float("nan"), lambda: None)
+            with self.assertRaises(ValueError):
+                loop.call_at(float("nan"), lambda: None)
+            with self.assertRaises(ValueError):
+                await asyncio.sleep(float("nan"))
+
+        rsloop.run(main())
+
+    def test_sleep_forever(self) -> None:
+        # Regression for upstream issue #48: asyncio.sleep(math.inf) (anyio's
+        # sleep_forever) should be valid and be canceallable.
+
+        async def main() -> None:
+            task = asyncio.create_task(asyncio.sleep(float("inf")))
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+        rsloop.run(main())
+
     def test_shutdown_default_executor_timeout_warns_and_falls_back_to_nowait(
         self,
     ) -> None:


### PR DESCRIPTION
Fixes #48. Clamp infinity and values too large for Duration (u64 secs) to around a century (to avoid overflow panics when doing arithmetic) Raises ValueError in NaN as python >=3.13 also does.