### PR TITLE
Ensure loop.create_datagram_endpoint with remote_addr set provides peername

### DIFF
--- a/python/rsloop/_loop_compat.py
+++ b/python/rsloop/_loop_compat.py
@@ -544,8 +544,7 @@ async def __loop_create_datagram_endpoint(
             raise OSError("getaddrinfo() returned empty list")
 
         family, socktype, proto, _, sockaddr = addrinfos[0]
-        if remote_addr is not None:
-            resolved_remote_addr = sockaddr
+        resolved_remote_addr = sockaddr if remote_addr is not None else None
         sock = __socket.socket(family=family, type=socktype, proto=proto)
         sock.setblocking(False)
         if reuse_port:
@@ -556,11 +555,16 @@ async def __loop_create_datagram_endpoint(
             sock.setsockopt(__socket.SOL_SOCKET, __socket.SO_BROADCAST, 1)
         if local_addr is not None:
             sock.bind(local_addr)
-        elif remote_addr is not None:
-            if family == __socket.AF_INET6:
-                sock.bind(("::", 0))
+        elif resolved_remote_addr is not None:
+            if allow_broadcast:
+                if family == __socket.AF_INET6:
+                    sock.bind(("::", 0))
+                else:
+                    sock.bind(("0.0.0.0", 0))
             else:
-                sock.bind(("0.0.0.0", 0))
+                # Connect the datagram socket so getpeername()/peername work and
+                # the local source address is filled in.
+                sock.connect(resolved_remote_addr)
     else:
         sock.setblocking(False)
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -569,6 +569,11 @@ class CompatibilityTests(unittest.TestCase):
                     remote_addr=("127.0.0.1", port),
                 )
                 try:
+                    # remote_addr connects the socket, so peername is populated.
+                    peername = client_transport.get_extra_info("peername")
+                    self.assertEqual(peername[:2], ("127.0.0.1", port))
+                    sock = client_transport.get_extra_info("socket")
+                    self.assertEqual(tuple(sock.getpeername()), tuple(peername))
                     return await asyncio.wait_for(done, 1.0)
                 finally:
                     client_transport.close()


### PR DESCRIPTION
Creating a udp endpoint with remote_addr set should create a connected socket with available `get_extra_info('peername')`

Yet again a failure in `anyio`s test-suite.
